### PR TITLE
Add the remaining placeheld policies and reorganize to implementation specific directory

### DIFF
--- a/certification/internal/policy/podmanexec/base_on_ubi.go
+++ b/certification/internal/policy/podmanexec/base_on_ubi.go
@@ -1,4 +1,4 @@
-package policy
+package podmanexec
 
 import (
 	"os/exec"
@@ -7,10 +7,9 @@ import (
 	"github.com/komish/preflight/certification"
 )
 
-type BasedOnUbiPolicy struct {
-}
+type BasedOnUbiPolicy struct{}
 
-func (p BasedOnUbiPolicy) Validate(image string) (bool, error) {
+func (p *BasedOnUbiPolicy) Validate(image string) (bool, error) {
 	stdouterr, err := exec.Command("podman", "run", "-it", image, "cat", "/etc/os-release").CombinedOutput()
 	if err != nil {
 		return false, err
@@ -33,11 +32,11 @@ func (p BasedOnUbiPolicy) Validate(image string) (bool, error) {
 	return false, nil
 }
 
-func (p BasedOnUbiPolicy) Name() string {
+func (p *BasedOnUbiPolicy) Name() string {
 	return "BasedOnUbi"
 }
 
-func (p BasedOnUbiPolicy) Metadata() certification.Metadata {
+func (p *BasedOnUbiPolicy) Metadata() certification.Metadata {
 	return certification.Metadata{
 		Description:      "Checking if the container's base image is based on UBI",
 		Level:            "best",
@@ -46,7 +45,7 @@ func (p BasedOnUbiPolicy) Metadata() certification.Metadata {
 	}
 }
 
-func (p BasedOnUbiPolicy) Help() certification.HelpText {
+func (p *BasedOnUbiPolicy) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "It is recommened that your image be based upon the Red Hat Universal Base Image (UBI)",
 		Suggestion: "Change the FROM directive in your Dockerfile or Containerfile to FROM registry.access.redhat.com/ubi8/ubi",

--- a/certification/internal/policy/podmanexec/has_license.go
+++ b/certification/internal/policy/podmanexec/has_license.go
@@ -1,0 +1,31 @@
+package podmanexec
+
+import (
+	"github.com/komish/preflight/certification"
+	"github.com/komish/preflight/certification/errors"
+)
+
+type HasLicensePolicy struct{}
+
+func (p *HasLicensePolicy) Validate(image string) (bool, error) {
+	return false, errors.ErrFeatureNotImplemented
+}
+func (p *HasLicensePolicy) Name() string {
+	return "HasLicense"
+}
+
+func (p *HasLicensePolicy) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checking if terms and conditions for images are present.",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		PolicyURL:        "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *HasLicensePolicy) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Container images must include terms and conditions applicable to the software including open source licensing information.",
+		Suggestion: "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
+	}
+}

--- a/certification/internal/policy/podmanexec/has_minimal_vulns.go
+++ b/certification/internal/policy/podmanexec/has_minimal_vulns.go
@@ -1,0 +1,31 @@
+package podmanexec
+
+import (
+	"github.com/komish/preflight/certification"
+	"github.com/komish/preflight/certification/errors"
+)
+
+type HasMinimalVulnerabilitiesPolicy struct{}
+
+func (p *HasMinimalVulnerabilitiesPolicy) Validate(image string) (bool, error) {
+	return false, errors.ErrFeatureNotImplemented
+}
+func (p *HasMinimalVulnerabilitiesPolicy) Name() string {
+	return "HasMinimalVulnerabilities"
+}
+
+func (p *HasMinimalVulnerabilitiesPolicy) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checking for critical or important security vulnerabilites.",
+		Level:            "good",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		PolicyURL:        "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *HasMinimalVulnerabilitiesPolicy) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Components in the container image cannot contain any critical or important vulnerabilities, as defined at https://access.redhat.com/security/updates/classification",
+		Suggestion: "Update your UBI image to the latest version or update the packages in your image to the latest versions distrubuted by Red Hat.",
+	}
+}

--- a/certification/internal/policy/podmanexec/has_prohibited_packages.go
+++ b/certification/internal/policy/podmanexec/has_prohibited_packages.go
@@ -1,0 +1,55 @@
+package podmanexec
+
+import (
+	"github.com/komish/preflight/certification"
+	"github.com/komish/preflight/certification/errors"
+)
+
+type HasNoProhibitedPackagesPolicy struct{}
+
+func (p *HasNoProhibitedPackagesPolicy) Validate(image string) (bool, error) {
+	return false, errors.ErrFeatureNotImplemented
+}
+func (p *HasNoProhibitedPackagesPolicy) Name() string {
+	return "HasNoProhibitedPackages"
+}
+func (p *HasNoProhibitedPackagesPolicy) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checks to ensure that the image in use does not contain prohibited packages.",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		PolicyURL:        "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+
+}
+
+func (p *HasNoProhibitedPackagesPolicy) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "The container image should not include Red Hat Enterprise Linux (RHEL) kernel packages.",
+		Suggestion: "Remove any RHEL packages that are not distributable outside of UBI",
+	}
+}
+
+// prohibitedPackageList is a list of packages commonly present in the RHEL contianer images that are not redistributable
+// without proper licensing (i.e. packages that are not under the same availability as those found in UBI).
+// TODO: Confirm these packages are the only packages in immediate scope.
+var prohibitedPackageList []string = []string{
+	"grub",
+	"grub2",
+	"kernel",
+	"kernel-core",
+	"kernel-debug",
+	"kernel-debug-core",
+	"kernel-debug-modules",
+	"kernel-debug-modules-extra",
+	"kernel-debug-devel",
+	"kernel-devel",
+	"kernel-doc",
+	"kernel-modules",
+	"kernel-modules-extra",
+	"kernel-tools",
+	"kernel-tools-libs",
+	"kmod-kvdo",
+	"kpatch*",
+	"linux-firmware",
+}

--- a/certification/internal/policy/podmanexec/has_required_labels.go
+++ b/certification/internal/policy/podmanexec/has_required_labels.go
@@ -1,4 +1,4 @@
-package policy
+package podmanexec
 
 import (
 	"github.com/komish/preflight/certification"
@@ -8,15 +8,15 @@ import (
 type HasRequiredLabelPolicy struct {
 }
 
-func (p HasRequiredLabelPolicy) Validate(image string) (bool, error) {
+func (p *HasRequiredLabelPolicy) Validate(image string) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 
-func (p HasRequiredLabelPolicy) Name() string {
+func (p *HasRequiredLabelPolicy) Name() string {
 	return "HasRequiredLabel"
 }
 
-func (p HasRequiredLabelPolicy) Metadata() certification.Metadata {
+func (p *HasRequiredLabelPolicy) Metadata() certification.Metadata {
 	return certification.Metadata{
 		Description:      "Checking if the container's base image is based on UBI",
 		Level:            "best",
@@ -25,7 +25,7 @@ func (p HasRequiredLabelPolicy) Metadata() certification.Metadata {
 	}
 }
 
-func (p HasRequiredLabelPolicy) Help() certification.HelpText {
+func (p *HasRequiredLabelPolicy) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "It is recommened that your image be based upon the Red Hat Universal Base Image (UBI)",
 		Suggestion: "Change the FROM directive in your Dockerfile or Containerfile to FROM registry.access.redhat.com/ubi8/ubi",

--- a/certification/internal/policy/podmanexec/has_unique_tag.go
+++ b/certification/internal/policy/podmanexec/has_unique_tag.go
@@ -1,0 +1,30 @@
+package podmanexec
+
+import (
+	"github.com/komish/preflight/certification"
+	"github.com/komish/preflight/certification/errors"
+)
+
+type HasUniqueTagPolicy struct{}
+
+func (p *HasUniqueTagPolicy) Validate(image string) (bool, error) {
+	return false, errors.ErrFeatureNotImplemented
+}
+func (p *HasUniqueTagPolicy) Name() string {
+	return "HasUniqueTag"
+}
+func (p *HasUniqueTagPolicy) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Checking if container has a tag other than 'latest'.",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		PolicyURL:        "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p *HasUniqueTagPolicy) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Containers should have a tag other than latest, so that the image can be uniquely identfied.",
+		Suggestion: "Add a tag to your image. Consider using Semantic Versioning. https://semver.org/",
+	}
+}

--- a/certification/internal/policy/podmanexec/less_than_max_layers.go
+++ b/certification/internal/policy/podmanexec/less_than_max_layers.go
@@ -1,4 +1,4 @@
-package policy
+package podmanexec
 
 import (
 	"github.com/komish/preflight/certification"
@@ -8,15 +8,15 @@ import (
 type UnderLayerMaxPolicy struct {
 }
 
-func (p UnderLayerMaxPolicy) Validate(image string) (bool, error) {
+func (p *UnderLayerMaxPolicy) Validate(image string) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 
-func (p UnderLayerMaxPolicy) Name() string {
+func (p *UnderLayerMaxPolicy) Name() string {
 	return "MaximumLayerPolicy"
 }
 
-func (p UnderLayerMaxPolicy) Metadata() certification.Metadata {
+func (p *UnderLayerMaxPolicy) Metadata() certification.Metadata {
 	return certification.Metadata{
 		Description:      "Checking if container has less than 40 layers",
 		Level:            "better",
@@ -25,7 +25,7 @@ func (p UnderLayerMaxPolicy) Metadata() certification.Metadata {
 	}
 }
 
-func (p UnderLayerMaxPolicy) Help() certification.HelpText {
+func (p *UnderLayerMaxPolicy) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "Uncompressed container images should have less than 40 layers. Too many layers within the container images can degrade container performance.",
 		Suggestion: "Optimize your Dockerfile to consolidate and minimize the number of layers. Each RUN command will produce a new layer. Try combining RUN commands using && where possible.",

--- a/certification/internal/policy/podmanexec/podmanexec.go
+++ b/certification/internal/policy/podmanexec/podmanexec.go
@@ -1,0 +1,4 @@
+// Package podmanexec contains policy implementations that rely on utilizing
+// Podman directly through the use of cmd.Exec. This implies that the
+// Podman CLI is installed and functional on a given system.
+package podmanexec

--- a/certification/internal/policy/podmanexec/runs_as_nonroot.go
+++ b/certification/internal/policy/podmanexec/runs_as_nonroot.go
@@ -1,4 +1,4 @@
-package policy
+package podmanexec
 
 import (
 	"github.com/komish/preflight/certification"
@@ -8,15 +8,15 @@ import (
 type RunAsNonRootPolicy struct {
 }
 
-func (p RunAsNonRootPolicy) Validate(image string) (bool, error) {
+func (p *RunAsNonRootPolicy) Validate(image string) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 
-func (p RunAsNonRootPolicy) Name() string {
+func (p *RunAsNonRootPolicy) Name() string {
 	return "RunAsNonRoot"
 }
 
-func (p RunAsNonRootPolicy) Metadata() certification.Metadata {
+func (p *RunAsNonRootPolicy) Metadata() certification.Metadata {
 	return certification.Metadata{
 		Description:      "Checking if container runs as the root user",
 		Level:            "best",
@@ -25,7 +25,7 @@ func (p RunAsNonRootPolicy) Metadata() certification.Metadata {
 	}
 }
 
-func (p RunAsNonRootPolicy) Help() certification.HelpText {
+func (p *RunAsNonRootPolicy) Help() certification.HelpText {
 	return certification.HelpText{
 		Message:    "A container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
 		Suggestion: "Indicate a specific USER in the dockerfile or containerfile",

--- a/certification/runtime/runner.go
+++ b/certification/runtime/runner.go
@@ -5,22 +5,35 @@ import (
 
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
-	"github.com/komish/preflight/certification/internal/policy"
+	"github.com/komish/preflight/certification/internal/policy/podmanexec"
 )
 
 // Register all policies
-var NameToPoliciesMap = map[string]certification.Policy{
-	policy.RunAsNonRootPolicy{}.Name():     policy.RunAsNonRootPolicy{},
-	policy.UnderLayerMaxPolicy{}.Name():    policy.UnderLayerMaxPolicy{},
-	policy.HasRequiredLabelPolicy{}.Name(): policy.HasRequiredLabelPolicy{},
-	policy.BasedOnUbiPolicy{}.Name():       policy.BasedOnUbiPolicy{},
+var runAsNonRootPolicy certification.Policy = &podmanexec.RunAsNonRootPolicy{}
+var underLayerMaxPolicy certification.Policy = &podmanexec.UnderLayerMaxPolicy{}
+var hasRequiredLabelPolicy certification.Policy = &podmanexec.HasRequiredLabelPolicy{}
+var basedOnUbiPolicy certification.Policy = &podmanexec.BasedOnUbiPolicy{}
+var hasLicensePolicy certification.Policy = &podmanexec.HasLicensePolicy{}
+var hasMinimalVulnerabilitiesPolicy certification.Policy = &podmanexec.HasMinimalVulnerabilitiesPolicy{}
+var hasUniqueTag certification.Policy = &podmanexec.HasUniqueTagPolicy{}
+var hasNoProhibitedPackages certification.Policy = &podmanexec.HasNoProhibitedPackagesPolicy{}
+
+var nameToPoliciesMap = map[string]certification.Policy{
+	runAsNonRootPolicy.Name():              runAsNonRootPolicy,
+	underLayerMaxPolicy.Name():             underLayerMaxPolicy,
+	hasRequiredLabelPolicy.Name():          hasRequiredLabelPolicy,
+	basedOnUbiPolicy.Name():                basedOnUbiPolicy,
+	hasLicensePolicy.Name():                hasLicensePolicy,
+	hasMinimalVulnerabilitiesPolicy.Name(): hasMinimalVulnerabilitiesPolicy,
+	hasUniqueTag.Name():                    hasUniqueTag,
+	hasNoProhibitedPackages.Name():         hasNoProhibitedPackages,
 }
 
 func AllPolicies() []string {
-	all := make([]string, len(NameToPoliciesMap))
+	all := make([]string, len(nameToPoliciesMap))
 	i := 0
 
-	for k := range NameToPoliciesMap {
+	for k := range nameToPoliciesMap {
 		all[i] = k
 		i++
 	}
@@ -41,7 +54,7 @@ func NewForConfig(config Config) (*policyRunner, error) {
 
 	policies := make([]certification.Policy, len(config.EnabledPolicies))
 	for i, policyString := range config.EnabledPolicies {
-		policy, exists := NameToPoliciesMap[policyString]
+		policy, exists := nameToPoliciesMap[policyString]
 		if !exists {
 			err := fmt.Errorf("%w: %s",
 				errors.ErrRequestedPolicyNotFound,


### PR DESCRIPTION
This PR migrates the remaining policies implemented on original PoCs, but with placeholder actions for the moment as some of them may not be in immediate scope. 

In addition, this PR reorganizes the location of the underlying implements to a subdirectory called `podmanexec`, separating the internal policy interface and struct definitions from the implementations themselves. This should allow us to just "create a new directory and start writing implementations" in a situation where we want to change the underlying implementation details (which we're currently researching by way of libpod, for example).

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>