### PR TITLE
Define formatter interfaces and enable user output adjustment

### DIFF
--- a/certification/errors/errors.go
+++ b/certification/errors/errors.go
@@ -4,6 +4,9 @@ import "errors"
 
 var ErrNoPoliciesEnabled = errors.New("no policies have been enabled")
 var ErrRequestedPolicyNotFound = errors.New("requested policy not found")
+var ErrRequestedFormatterNotFound = errors.New("requested formatter is not known")
+var ErrFormatterNameNotProvided = errors.New("formatter name is required")
 var ErrFormattingResults = errors.New("error formatting results")
 var ErrFeatureNotImplemented = errors.New("feature not implemented") // TODO remove this ASAP
 var ErrInsufficientPosArguments = errors.New("not enough positional arguments")
+var ErrNoResponseFormatSpecified = errors.New("no response format specified")

--- a/certification/formatters/generic.go
+++ b/certification/formatters/generic.go
@@ -1,0 +1,46 @@
+package formatters
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+
+	"github.com/komish/preflight/certification/errors"
+	"github.com/komish/preflight/certification/runtime"
+)
+
+// genericJSONFormatter is a FormatterFunc that formats results as JSON
+func genericJSONFormatter(r runtime.Results) ([]byte, error) {
+	response := getResponse(r)
+
+	responseJSON, err := json.MarshalIndent(response, "", "    ")
+	if err != nil {
+		e := fmt.Errorf("%w with formatter %s: %s",
+			errors.ErrFormattingResults,
+			"json",
+			err,
+		)
+
+		return nil, e
+	}
+
+	return responseJSON, nil
+}
+
+// genericXMLFormatter is a FormatterFunc that formats results as XML
+func genericXMLFormatter(r runtime.Results) ([]byte, error) {
+	response := getResponse(r)
+
+	responseJSON, err := xml.MarshalIndent(response, "", "    ")
+	if err != nil {
+		e := fmt.Errorf("%w with formatter %s: %s",
+			errors.ErrFormattingResults,
+			"json",
+			err,
+		)
+
+		return nil, e
+	}
+
+	return responseJSON, nil
+}

--- a/certification/formatters/junitxml.go
+++ b/certification/formatters/junitxml.go
@@ -1,0 +1,12 @@
+package formatters
+
+import (
+	"fmt"
+
+	"github.com/komish/preflight/certification/errors"
+	"github.com/komish/preflight/certification/runtime"
+)
+
+func junitXMLFormatter(r runtime.Results) ([]byte, error) {
+	return nil, fmt.Errorf("%w: The JUnit XML Formatter is not implemented", errors.ErrFeatureNotImplemented)
+}

--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -1,0 +1,48 @@
+package formatters
+
+import (
+	"github.com/komish/preflight/certification/internal/policy"
+	"github.com/komish/preflight/certification/runtime"
+	"github.com/komish/preflight/version"
+)
+
+// getResponse will extract the runtime's results and format it to fit the
+// UserResponse definition in a way that can then be formatted.
+func getResponse(r runtime.Results) runtime.UserResponse {
+	passedPolicies := make([]policy.Metadata, len(r.Passed))
+	failedPolicies := make([]policy.PolicyInfo, len(r.Failed))
+	erroredPolicies := make([]policy.HelpText, len(r.Errors))
+
+	if len(r.Passed) > 0 {
+		for i, policyData := range r.Passed {
+			passedPolicies[i] = policyData.Meta()
+		}
+	}
+
+	if len(r.Failed) > 0 {
+		for i, policyData := range r.Failed {
+			failedPolicies[i] = policy.PolicyInfo{
+				Metadata: policyData.Meta(),
+				HelpText: policyData.Help(),
+			}
+		}
+	}
+
+	if len(r.Errors) > 0 {
+		for i, policyData := range r.Errors {
+			erroredPolicies[i] = policyData.Help()
+		}
+	}
+
+	response := runtime.UserResponse{
+		Image:             r.TestedImage,
+		ValidationVersion: version.Version,
+		Results: runtime.UserResponseText{
+			Passed: passedPolicies,
+			Failed: failedPolicies,
+			Errors: erroredPolicies,
+		},
+	}
+
+	return response
+}

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -3,4 +3,5 @@ package runtime
 type Config struct {
 	Image           string
 	EnabledPolicies []string
+	ResponseFormat  string
 }


### PR DESCRIPTION
This PR formalizes and organizes the formatting interfaces, which allows users to specify their choice in output formats. The output interfaces are responsible for taking in a given test result struct, and formatting it for writing. The current design is entirely decoupled from the runner interface, as they share nothing more than a configuration which informs them for the moment. Always open to change on that front.

More specifically, this PR will update the `formatters` package to formally define a `ResponseFormatter`, and a `GenericFormatter` struct which implements this interface and is used for building the built-in formatters.

The previous public functions that were used to format the output were pushed to private functions and wrapped in the `GenericFormatter` through an access functions which parses the user configuration. Also a `New()` instantiator was provided to enable use cases where a custom formatter is to be built by developers.

Finally, some organizational changes, such as placing the now-private formatters into their own file, and moving utility functions to a `util.go` to keep the main `formatters.go` file clean.

The RootCMD has now been updated to properly use this formatter as a result of the user configuration. The `PREFLIGHT_OUTPUT_FORMAT` variable has been wired in to allow a user to specify their values of the built-in formatters. Alternatively, the `--output-format` flag should accomplish the same.

```
$ PREFLIGHT_OUTPUT_FORMAT=json ./preflight someimage | head -2
{
    "image": "someimage",

$ PREFLIGHT_OUTPUT_FORMAT=xml ./preflight someimage | head -2
<UserResponse>
    <image>someimage</image>
```

The supported formatters has also been added to help output:

```
A utility that allows you to pre-test your bundles, operators, and container before submitting for Red Hat Certification.
Choose from any of the following policies:
        under_40_layers, is_ubi_based, nonroot, has_required_labels
Choose from any of the following output formats:
        json, xml, junitxml
...
```

A quick note that while the supported formats shows junitxml, that formatter is just stubbed and needs implementation.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>