### PR TITLE
Implement Validate operator bundle test

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -71,6 +71,7 @@ var hasLicenseCheck certification.Check = &podmanexec.HasLicenseCheck{}
 var hasMinimalVulnerabilitiesCheck certification.Check = &podmanexec.HasMinimalVulnerabilitiesCheck{}
 var hasUniqueTagCheck certification.Check = &podmanexec.HasUniqueTagCheck{}
 var hasNoProhibitedCheck certification.Check = &podmanexec.HasNoProhibitedPackagesCheck{}
+var validateOperatorBundle certification.Check = &podmanexec.ValidateOperatorBundlePolicy{}
 
 var nameToChecksMap = map[string]certification.Check{
 	// NOTE(komish): these checks do not all apply to bundles, which is the current
@@ -84,6 +85,7 @@ var nameToChecksMap = map[string]certification.Check{
 	hasMinimalVulnerabilitiesCheck.Name(): hasMinimalVulnerabilitiesCheck,
 	hasUniqueTagCheck.Name():              hasUniqueTagCheck,
 	hasNoProhibitedCheck.Name():           hasNoProhibitedCheck,
+	validateOperatorBundle.Name():         validateOperatorBundle,
 }
 
 func AllChecks() []string {

--- a/certification/internal/shell/validate_operator_bundle.go
+++ b/certification/internal/shell/validate_operator_bundle.go
@@ -1,0 +1,48 @@
+package shell
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/komish/preflight/certification"
+	"github.com/sirupsen/logrus"
+)
+
+type ValidateOperatorBundlePolicy struct {
+}
+
+func (p ValidateOperatorBundlePolicy) Validate(bundle string, logger *logrus.Logger) (bool, error) {
+	stdouterr, err := exec.Command("operator-sdk", "bundle", "validate", "--verbose", bundle).CombinedOutput()
+	if err != nil {
+		logger.Error("Error will executing operator-sdk validate bundle: ", err)
+		return false, err
+	}
+
+	lines := strings.Split(string(stdouterr), "time=")
+
+	if strings.Contains(lines[len(lines)-1], "All validation tests have completed successfully") {
+		return true, nil
+	}
+	logger.Warn("The bundle image did not pass all of the validation tests")
+	return false, nil
+}
+
+func (p ValidateOperatorBundlePolicy) Name() string {
+	return "ValidateOperatorBundle"
+}
+
+func (p ValidateOperatorBundlePolicy) Metadata() certification.Metadata {
+	return certification.Metadata{
+		Description:      "Validating Bundle image",
+		Level:            "best",
+		KnowledgeBaseURL: "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+		CheckURL:         "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
+	}
+}
+
+func (p ValidateOperatorBundlePolicy) Help() certification.HelpText {
+	return certification.HelpText{
+		Message:    "Operator sdk validation test failed, this test checks if it can validate the content and format of the operator bundle",
+		Suggestion: "Valid bundles are definied by bundle spec, so make sure that this bundle conforms to that spec. More Information: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md",
+	}
+}


### PR DESCRIPTION
This is the implementation for the validate operator bundle test. This test runs operator-sdk bundle validate against the bundle image and makes sure that all of the validation tests pass.