### PR TITLE
Rename podmanexec lib to a more appropriate name - shell

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
-	"github.com/komish/preflight/certification/internal/policy/podmanexec"
+	podmanexec "github.com/komish/preflight/certification/internal/shell"
 	"github.com/komish/preflight/certification/runtime"
 )
 

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"os/exec"

--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"fmt"

--- a/certification/internal/shell/has_license.go
+++ b/certification/internal/shell/has_license.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"github.com/komish/preflight/certification"

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"github.com/komish/preflight/certification"

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"github.com/komish/preflight/certification"

--- a/certification/internal/shell/has_required_labels.go
+++ b/certification/internal/shell/has_required_labels.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"github.com/komish/preflight/certification"

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"github.com/komish/preflight/certification"

--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"github.com/komish/preflight/certification"

--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -1,4 +1,4 @@
-package podmanexec
+package shell
 
 import (
 	"github.com/komish/preflight/certification"

--- a/certification/internal/shell/shell.go
+++ b/certification/internal/shell/shell.go
@@ -1,4 +1,4 @@
-// Package podmanexec contains policy implementations that rely on utilizing
+// package shell contains policy implementations that rely on utilizing
 // Podman directly through the use of cmd.Exec. This implies that the
 // Podman CLI is installed and functional on a given system.
-package podmanexec
+package shell


### PR DESCRIPTION
The `podmanexec` library name was confusing, and implied that we were strictly required, or planning on using `podman` exclusively for all checks. Most of the tests we're running are shell-specific, so this has been renamed.

I moved `shell` up a level, and drop the `internal/policy` library (where `podmanexec` previously was housed) as it is now empty.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>