### PR TITLE
Add an elapsed time to policy results

### DIFF
--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"time"
+
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/version"
 )
@@ -10,11 +12,17 @@ type Config struct {
 	EnabledChecks  []string
 	ResponseFormat string
 }
+
+type Result struct {
+	certification.Check
+	ElapsedTime time.Duration
+}
+
 type Results struct {
 	TestedImage string
-	Passed      []certification.Check
-	Failed      []certification.Check
-	Errors      []certification.Check
+	Passed      []Result
+	Failed      []Result
+	Errors      []Result
 }
 
 type UserResponse struct {


### PR DESCRIPTION
Some of the output formatters like to report a time elapsed (like JUnitXML).
This adds support for that by introducing a Result type, and composing on top
of Policy type to add an ElapsedTime field.

Signed-off-by: Brad P. Crochet <brad@redhat.com>