### PR TITLE
Add command execution visibility in log files and response output

### DIFF
--- a/certification/certification.go
+++ b/certification/certification.go
@@ -4,7 +4,7 @@ package certification
 // to use and identify a given policy.
 type Policy interface {
 	// Validate whether the asset enforces the policy.
-	Validate(image string) (result bool, err error)
+	Validate(image string) (result bool, log []byte, err error)
 	// return the name of the policy
 	Name() string
 	// return the policy's metadata
@@ -27,7 +27,29 @@ type HelpText struct {
 	Suggestion string `json:"suggestion" xml:"suggestion"`
 }
 
+type Log = []byte
+
+type PolicyWithRuntimeLog struct {
+	Policy Policy
+	Log    Log `json:"log,omitempty" xml:"log,omitempty"`
+}
+
 type PolicyInfo struct {
 	Metadata `json:"metadata" xml:"metadata"`
 	HelpText `json:"helptext"`
+}
+
+type PolicyMetadataWithLog struct {
+	Metadata
+	Log `json:"log,omitempty" xml:"log,omitempty"`
+}
+
+type PolicyInfoWithLog struct {
+	PolicyInfo
+	Log `json:"log,omitempty" xml:"log,omitempty"`
+}
+
+type PolicyHelpTextWithLog struct {
+	HelpText
+	Log `json:"log,omitempty" xml:"log,omitempty"`
 }

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -32,7 +32,12 @@ type PolicyRunner interface {
 	ExecutePolicies()
 	// StorePolicies(...[]certification.Policy)
 	Results() runtime.Results
+	Logs() LogMap
 }
+
+// LogMap is a map of logfiles to write (the key), and the data to write to
+// it (the byte slice).
+type LogMap = map[string][]byte
 
 func NewForConfig(config runtime.Config) (PolicyRunner, error) {
 	if len(config.EnabledPolicies) == 0 {

--- a/certification/formatters/junitxml.go
+++ b/certification/formatters/junitxml.go
@@ -30,6 +30,7 @@ type JUnitTestCase struct {
 	Time        string            `xml:"time,attr"`
 	SkipMessage *JUnitSkipMessage `xml:"skipped,omitempty"`
 	Failure     *JUnitFailure     `xml:"failure,omitempty"`
+	SystemOut   string            `xml:"system-out,omitempty"`
 }
 
 type JUnitSkipMessage struct {
@@ -62,9 +63,10 @@ func junitXMLFormatter(r runtime.Results) ([]byte, error) {
 	for _, result := range r.Passed {
 		testCase := JUnitTestCase{
 			Classname: response.Image,
-			Name:      result.Name(),
+			Name:      result.Policy.Name(),
 			Time:      "0s",
 			Failure:   nil,
+			SystemOut: string(result.Log),
 		}
 		testsuite.TestCases = append(testsuite.TestCases, testCase)
 	}
@@ -72,13 +74,15 @@ func junitXMLFormatter(r runtime.Results) ([]byte, error) {
 	for _, result := range append(r.Errors, r.Failed...) {
 		testCase := JUnitTestCase{
 			Classname: response.Image,
-			Name:      result.Name(),
-			Time:      "0s",
+			Name:      result.Policy.Name(),
+
+			Time: "0s",
 			Failure: &JUnitFailure{
 				Message:  "Failed",
 				Type:     "",
-				Contents: fmt.Sprintf("%s: Suggested Fix: %s", result.Help().Message, result.Help().Suggestion),
+				Contents: fmt.Sprintf("%s: Suggested Fix: %s", result.Policy.Help().Message, result.Policy.Help().Suggestion),
 			},
+			SystemOut: string(result.Log),
 		}
 		testsuite.TestCases = append(testsuite.TestCases, testCase)
 	}

--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -9,28 +9,37 @@ import (
 // getResponse will extract the runtime's results and format it to fit the
 // UserResponse definition in a way that can then be formatted.
 func getResponse(r runtime.Results) runtime.UserResponse {
-	passedPolicies := make([]certification.Metadata, len(r.Passed))
-	failedPolicies := make([]certification.PolicyInfo, len(r.Failed))
-	erroredPolicies := make([]certification.HelpText, len(r.Errors))
+	passedPolicies := make([]certification.PolicyMetadataWithLog, len(r.Passed))
+	failedPolicies := make([]certification.PolicyInfoWithLog, len(r.Failed))
+	erroredPolicies := make([]certification.PolicyHelpTextWithLog, len(r.Errors))
 
 	if len(r.Passed) > 0 {
-		for i, policyData := range r.Passed {
-			passedPolicies[i] = policyData.Metadata()
+		for i, execution := range r.Passed {
+			passedPolicies[i] = certification.PolicyMetadataWithLog{
+				Metadata: execution.Policy.Metadata(),
+				// Log:      execution.Log,
+			}
 		}
 	}
 
 	if len(r.Failed) > 0 {
-		for i, policyData := range r.Failed {
-			failedPolicies[i] = certification.PolicyInfo{
-				Metadata: policyData.Metadata(),
-				HelpText: policyData.Help(),
+		for i, execution := range r.Failed {
+			failedPolicies[i] = certification.PolicyInfoWithLog{
+				PolicyInfo: certification.PolicyInfo{
+					Metadata: execution.Policy.Metadata(),
+					HelpText: execution.Policy.Help(),
+				},
+				// Log: execution.Log,
 			}
 		}
 	}
 
 	if len(r.Errors) > 0 {
-		for i, policyData := range r.Errors {
-			erroredPolicies[i] = policyData.Help()
+		for i, execution := range r.Errors {
+			erroredPolicies[i] = certification.PolicyHelpTextWithLog{
+				HelpText: execution.Policy.Help(),
+				// Log:      execution.Log,
+			}
 		}
 	}
 

--- a/certification/generic_policy_definition.go
+++ b/certification/generic_policy_definition.go
@@ -2,7 +2,7 @@ package certification
 
 // ValidatorFunc describes a function that, when executed, will check that an
 // artifact (e.g. operator bundle) complies with a given policy.
-type ValidatorFunc = func(string) (bool, error)
+type ValidatorFunc = func(string) (bool, []byte, error)
 
 type genericPolicyDefinition struct {
 	name        string
@@ -15,7 +15,7 @@ func (pd *genericPolicyDefinition) Name() string {
 	return pd.name
 }
 
-func (pd *genericPolicyDefinition) Validate(image string) (bool, error) {
+func (pd *genericPolicyDefinition) Validate(image string) (bool, []byte, error) {
 	return pd.validatorFn(image)
 }
 

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -9,10 +9,10 @@ import (
 
 type BasedOnUbiPolicy struct{}
 
-func (p *BasedOnUbiPolicy) Validate(image string) (bool, error) {
+func (p *BasedOnUbiPolicy) Validate(image string) (bool, []byte, error) {
 	stdouterr, err := exec.Command("podman", "run", "--rm", "-it", image, "cat", "/etc/os-release").CombinedOutput()
 	if err != nil {
-		return false, err
+		return false, stdouterr, err
 	}
 
 	lines := strings.Split(string(stdouterr), "\n")
@@ -26,10 +26,10 @@ func (p *BasedOnUbiPolicy) Validate(image string) (bool, error) {
 		}
 	}
 	if hasRHELID && hasRHELName {
-		return true, nil
+		return true, []byte{}, nil
 	}
 
-	return false, nil
+	return false, []byte{}, nil
 }
 
 func (p *BasedOnUbiPolicy) Name() string {

--- a/certification/internal/shell/has_license.go
+++ b/certification/internal/shell/has_license.go
@@ -7,9 +7,10 @@ import (
 
 type HasLicensePolicy struct{}
 
-func (p *HasLicensePolicy) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+func (p *HasLicensePolicy) Validate(image string) (bool, []byte, error) {
+	return false, []byte{}, errors.ErrFeatureNotImplemented
 }
+
 func (p *HasLicensePolicy) Name() string {
 	return "HasLicense"
 }

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -7,8 +7,8 @@ import (
 
 type HasMinimalVulnerabilitiesPolicy struct{}
 
-func (p *HasMinimalVulnerabilitiesPolicy) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+func (p *HasMinimalVulnerabilitiesPolicy) Validate(image string) (bool, []byte, error) {
+	return false, []byte{}, errors.ErrFeatureNotImplemented
 }
 func (p *HasMinimalVulnerabilitiesPolicy) Name() string {
 	return "HasMinimalVulnerabilities"

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -7,8 +7,8 @@ import (
 
 type HasNoProhibitedPackagesPolicy struct{}
 
-func (p *HasNoProhibitedPackagesPolicy) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+func (p *HasNoProhibitedPackagesPolicy) Validate(image string) (bool, []byte, error) {
+	return false, []byte{}, errors.ErrFeatureNotImplemented
 }
 func (p *HasNoProhibitedPackagesPolicy) Name() string {
 	return "HasNoProhibitedPackages"

--- a/certification/internal/shell/has_required_labels.go
+++ b/certification/internal/shell/has_required_labels.go
@@ -8,8 +8,8 @@ import (
 type HasRequiredLabelPolicy struct {
 }
 
-func (p *HasRequiredLabelPolicy) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+func (p *HasRequiredLabelPolicy) Validate(image string) (bool, []byte, error) {
+	return false, []byte{}, errors.ErrFeatureNotImplemented
 }
 
 func (p *HasRequiredLabelPolicy) Name() string {

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -7,8 +7,8 @@ import (
 
 type HasUniqueTagPolicy struct{}
 
-func (p *HasUniqueTagPolicy) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+func (p *HasUniqueTagPolicy) Validate(image string) (bool, []byte, error) {
+	return false, []byte{}, errors.ErrFeatureNotImplemented
 }
 func (p *HasUniqueTagPolicy) Name() string {
 	return "HasUniqueTag"

--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -8,8 +8,8 @@ import (
 type UnderLayerMaxPolicy struct {
 }
 
-func (p *UnderLayerMaxPolicy) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+func (p *UnderLayerMaxPolicy) Validate(image string) (bool, []byte, error) {
+	return false, []byte{}, errors.ErrFeatureNotImplemented
 }
 
 func (p *UnderLayerMaxPolicy) Name() string {

--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -8,8 +8,8 @@ import (
 type RunAsNonRootPolicy struct {
 }
 
-func (p *RunAsNonRootPolicy) Validate(image string) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+func (p *RunAsNonRootPolicy) Validate(image string) (bool, []byte, error) {
+	return false, []byte{}, errors.ErrFeatureNotImplemented
 }
 
 func (p *RunAsNonRootPolicy) Name() string {

--- a/certification/runtime/runtime.go
+++ b/certification/runtime/runtime.go
@@ -12,9 +12,9 @@ type Config struct {
 }
 type Results struct {
 	TestedImage string
-	Passed      []certification.Policy
-	Failed      []certification.Policy
-	Errors      []certification.Policy
+	Passed      []certification.PolicyWithRuntimeLog
+	Failed      []certification.PolicyWithRuntimeLog
+	Errors      []certification.PolicyWithRuntimeLog
 }
 
 type UserResponse struct {
@@ -24,9 +24,9 @@ type UserResponse struct {
 }
 
 type UserResponseText struct {
-	Passed []certification.Metadata
-	Failed []certification.PolicyInfo
-	Errors []certification.HelpText
+	Passed []certification.PolicyMetadataWithLog
+	Failed []certification.PolicyInfoWithLog
+	Errors []certification.PolicyHelpTextWithLog
 	// TODO: Errors does not actually include any error information
 	// and it needs to do so.
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -47,6 +48,17 @@ var rootCmd = &cobra.Command{
 		engine.ExecutePolicies()
 		results := engine.Results()
 
+		// write logs
+		// TODO dynamically accept logging directories
+		logs := engine.Logs()
+		for file, data := range logs {
+			err := ioutil.WriteFile(file, data, 0644)
+			if err != nil {
+				return fmt.Errorf("%w: unable to write log file %s", err, file)
+			}
+		}
+
+		// return results to the user
 		formattedResults, err := formatter.Format(results)
 		if err != nil {
 			return err


### PR DESCRIPTION
We've been missing command execution logs in the current shell/podmanexec implementation. This PR defines an method `logs()` in the PolicyEngine interface that allows for accessing a log map (filename and data). Our CLI execution (root.go) then queries those logs and writes them to disk at the file specified. 

This PR also adds in support optionally returning that log output from the `Validate()` call. ~which then gets injected into the UserResponse. You can optionally return nothing to this, and just rely on the logs on disk.~ - it's up the implementation. Right now, in this PR, we return both.

~Formatters have been updated to return this information. If we want to remove that later, that's fine 👍. Specifically, I had to restructure the `Results` struct a bit to include the log information, so the JUnitXMLFormatter saw some updates in how the Policy-related methods are referenced.~ (see edit) I also added the `system-out` key to accommodate the new data.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

EDIT: I pulled out the user response, as each formatter formatted the byte slice differently. Just cleaner to rely on the log file, I think.