### PR TITLE
Install oc and operator-sdk in Vagrant, and put go first in the path

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,6 @@ Vagrant.configure("2") do |config|
     skopeo \
     jq \
     make \
-    golang \
     bats \
     btrfs-progs-devel \
     device-mapper-devel \
@@ -34,7 +33,7 @@ Vagrant.configure("2") do |config|
     export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.9.0
     curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
     chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
-    echo "PATH=$PATH:/usr/local/go/bin" >> /home/vagrant/.bashrc
-    echo "PATH=$PATH:/usr/local/go/bin" >> /root/.bashrc
+    echo "PATH=/usr/local/go/bin:$PATH" >> /home/vagrant/.bashrc
+    echo "PATH=/usr/local/go/bin:$PATH" >> /root/.bashrc
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,15 @@ Vagrant.configure("2") do |config|
     containers-common
     curl -L https://golang.org/dl/go1.16.3.linux-amd64.tar.gz --output go1.16.3.linux-amd64.tar.gz
     rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz
+    rm go1.16.3.linux-amd64.tar.gz
+    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz --output oc.tar.gz
+    tar -C /usr/local/bin -xzf oc.tar.gz
+    rm oc.tar.gz
+    export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+    export OS=$(uname | awk '{print tolower($0)}')
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.9.0
+    curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+    chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk    
     echo "PATH=$PATH:/usr/local/go/bin" >> /home/vagrant/.bashrc
     echo "PATH=$PATH:/usr/local/go/bin" >> /root/.bashrc
   SHELL


### PR DESCRIPTION
oc and operator-sdk will be prereqs for some of the checks. Install these
in the Vagrant box.

Signed-off-by: Brad P. Crochet <brad@redhat.com>