### PR TITLE
Add a logging implementation

### DIFF
--- a/certification/certification.go
+++ b/certification/certification.go
@@ -1,10 +1,12 @@
 package certification
 
+import "github.com/sirupsen/logrus"
+
 // Policy as an interface containing all methods necessary
 // to use and identify a given policy.
 type Policy interface {
 	// Validate whether the asset enforces the policy.
-	Validate(image string) (result bool, err error)
+	Validate(image string, logger *logrus.Logger) (result bool, err error)
 	// return the name of the policy
 	Name() string
 	// return the policy's metadata

--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/komish/preflight/certification/errors"
 	podmanexec "github.com/komish/preflight/certification/internal/shell"
 	"github.com/komish/preflight/certification/runtime"
+	"github.com/sirupsen/logrus"
 )
 
 type PolicyEngine interface {
@@ -20,16 +21,16 @@ type ContainerFileManager interface {
 	// IsRemote will check user-provided path and determine if that path is
 	// local or remote. Here local means that it's a location on the filesystem, and
 	// remote means that it's an image in a registry.
-	ContainerIsRemote(path string) (isRemote bool, remotecheckErr error)
+	ContainerIsRemote(path string, logger *logrus.Logger) (isRemote bool, remotecheckErr error)
 	// ExtractContainerTar will accept a path on the filesystem and extract it.
-	ExtractContainerTar(path string) (tarballPath string, extractionErr error)
+	ExtractContainerTar(path string, logger *logrus.Logger) (tarballPath string, extractionErr error)
 	// GetContainerFromRegistry will accept a container location and write it locally
 	// as a tarball as done by `podman save`
-	GetContainerFromRegistry(containerLoc string) (containerDownloadPath string, containerDownloadErro error)
+	GetContainerFromRegistry(containerLoc string, logger *logrus.Logger) (containerDownloadPath string, containerDownloadErro error)
 }
 
 type PolicyRunner interface {
-	ExecutePolicies()
+	ExecutePolicies(logger *logrus.Logger)
 	// StorePolicies(...[]certification.Policy)
 	Results() runtime.Results
 }

--- a/certification/formatters/junitxml.go
+++ b/certification/formatters/junitxml.go
@@ -30,6 +30,7 @@ type JUnitTestCase struct {
 	Time        string            `xml:"time,attr"`
 	SkipMessage *JUnitSkipMessage `xml:"skipped,omitempty"`
 	Failure     *JUnitFailure     `xml:"failure,omitempty"`
+	SystemOut   string            `xml:"system-out,omitempty"`
 }
 
 type JUnitSkipMessage struct {

--- a/certification/formatters/util.go
+++ b/certification/formatters/util.go
@@ -14,23 +14,23 @@ func getResponse(r runtime.Results) runtime.UserResponse {
 	erroredPolicies := make([]certification.HelpText, len(r.Errors))
 
 	if len(r.Passed) > 0 {
-		for i, policyData := range r.Passed {
-			passedPolicies[i] = policyData.Metadata()
+		for i, policy := range r.Passed {
+			passedPolicies[i] = policy.Metadata()
 		}
 	}
 
 	if len(r.Failed) > 0 {
-		for i, policyData := range r.Failed {
+		for i, policyInfo := range r.Failed {
 			failedPolicies[i] = certification.PolicyInfo{
-				Metadata: policyData.Metadata(),
-				HelpText: policyData.Help(),
+				Metadata: policyInfo.Metadata(),
+				HelpText: policyInfo.Help(),
 			}
 		}
 	}
 
 	if len(r.Errors) > 0 {
-		for i, policyData := range r.Errors {
-			erroredPolicies[i] = policyData.Help()
+		for i, policy := range r.Errors {
+			erroredPolicies[i] = policy.Help()
 		}
 	}
 

--- a/certification/generic_policy_definition.go
+++ b/certification/generic_policy_definition.go
@@ -1,8 +1,10 @@
 package certification
 
+import "github.com/sirupsen/logrus"
+
 // ValidatorFunc describes a function that, when executed, will check that an
 // artifact (e.g. operator bundle) complies with a given policy.
-type ValidatorFunc = func(string) (bool, error)
+type ValidatorFunc = func(string, *logrus.Logger) (bool, error)
 
 type genericPolicyDefinition struct {
 	name        string
@@ -15,8 +17,8 @@ func (pd *genericPolicyDefinition) Name() string {
 	return pd.name
 }
 
-func (pd *genericPolicyDefinition) Validate(image string) (bool, error) {
-	return pd.validatorFn(image)
+func (pd *genericPolicyDefinition) Validate(image string, logger *logrus.Logger) (bool, error) {
+	return pd.validatorFn(image, logger)
 }
 
 func (pd *genericPolicyDefinition) Metadata() Metadata {

--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -5,13 +5,15 @@ import (
 	"strings"
 
 	"github.com/komish/preflight/certification"
+	"github.com/sirupsen/logrus"
 )
 
 type BasedOnUbiPolicy struct{}
 
-func (p *BasedOnUbiPolicy) Validate(image string) (bool, error) {
+func (p *BasedOnUbiPolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	stdouterr, err := exec.Command("podman", "run", "--rm", "-it", image, "cat", "/etc/os-release").CombinedOutput()
 	if err != nil {
+		logger.Error("unable to inspect the os-release file in the target container: ", err)
 		return false, err
 	}
 

--- a/certification/internal/shell/has_license.go
+++ b/certification/internal/shell/has_license.go
@@ -3,13 +3,15 @@ package shell
 import (
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type HasLicensePolicy struct{}
 
-func (p *HasLicensePolicy) Validate(image string) (bool, error) {
+func (p *HasLicensePolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
+
 func (p *HasLicensePolicy) Name() string {
 	return "HasLicense"
 }

--- a/certification/internal/shell/has_minimal_vulns.go
+++ b/certification/internal/shell/has_minimal_vulns.go
@@ -3,11 +3,12 @@ package shell
 import (
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type HasMinimalVulnerabilitiesPolicy struct{}
 
-func (p *HasMinimalVulnerabilitiesPolicy) Validate(image string) (bool, error) {
+func (p *HasMinimalVulnerabilitiesPolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 func (p *HasMinimalVulnerabilitiesPolicy) Name() string {

--- a/certification/internal/shell/has_prohibited_packages.go
+++ b/certification/internal/shell/has_prohibited_packages.go
@@ -3,11 +3,12 @@ package shell
 import (
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type HasNoProhibitedPackagesPolicy struct{}
 
-func (p *HasNoProhibitedPackagesPolicy) Validate(image string) (bool, error) {
+func (p *HasNoProhibitedPackagesPolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 func (p *HasNoProhibitedPackagesPolicy) Name() string {

--- a/certification/internal/shell/has_required_labels.go
+++ b/certification/internal/shell/has_required_labels.go
@@ -3,12 +3,13 @@ package shell
 import (
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type HasRequiredLabelPolicy struct {
 }
 
-func (p *HasRequiredLabelPolicy) Validate(image string) (bool, error) {
+func (p *HasRequiredLabelPolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 

--- a/certification/internal/shell/has_unique_tag.go
+++ b/certification/internal/shell/has_unique_tag.go
@@ -3,11 +3,12 @@ package shell
 import (
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type HasUniqueTagPolicy struct{}
 
-func (p *HasUniqueTagPolicy) Validate(image string) (bool, error) {
+func (p *HasUniqueTagPolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 func (p *HasUniqueTagPolicy) Name() string {

--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -3,12 +3,13 @@ package shell
 import (
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type UnderLayerMaxPolicy struct {
 }
 
-func (p *UnderLayerMaxPolicy) Validate(image string) (bool, error) {
+func (p *UnderLayerMaxPolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 

--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -3,12 +3,13 @@ package shell
 import (
 	"github.com/komish/preflight/certification"
 	"github.com/komish/preflight/certification/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type RunAsNonRootPolicy struct {
 }
 
-func (p *RunAsNonRootPolicy) Validate(image string) (bool, error) {
+func (p *RunAsNonRootPolicy) Validate(image string, logger *logrus.Logger) (bool, error) {
 	return false, errors.ErrFeatureNotImplemented
 }
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var logger *logrus.Logger
+
+func init() {
+	logger = logrus.New()
+
+	time := time.Now().Unix()
+	logname := fmt.Sprintf("preflight-%d.log", time)
+	logFile, err := os.OpenFile(logname, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0700)
+	if err == nil {
+		mw := io.MultiWriter(os.Stdout, logFile)
+		logger.SetOutput(mw)
+	} else {
+		logger.Info("Failed to log to file, using default stderr")
+	}
+	logger.SetFormatter(&logrus.TextFormatter{})
+	logger.SetLevel(logrus.TraceLevel)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,9 +44,10 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		engine.ExecutePolicies()
+		engine.ExecutePolicies(logger)
 		results := engine.Results()
 
+		// return results to the user
 		formattedResults, err := formatter.Format(results)
 		if err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/komish/preflight
 
 go 1.14
 
-require github.com/spf13/cobra v1.1.3
+require (
+	github.com/sirupsen/logrus v1.7.0
+	github.com/spf13/cobra v1.1.3
+)

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -99,8 +100,10 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -123,6 +126,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -140,7 +144,10 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -157,6 +164,7 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -171,6 +179,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -224,7 +233,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -278,6 +290,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Adds a logger, and passes it to the various methods that might need it. Sample execution is below, and this also writes to preflight.log (grabbed this from the PoC repo).

The logs that are emitted can probably be tweaked, but each unimplemented policy can leverage this as they see fit.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

```
../preflight registry.access.redhat.com/ubi8/ubi:latest 
time="2021-06-25T08:13:01-05:00" level=info msg="target image: registry.access.redhat.com/ubi8/ubi:latest"
time="2021-06-25T08:13:01-05:00" level=info msg="downloading image"
time="2021-06-25T08:13:07-05:00" level=info msg="running check: HasNoProhibitedPackages"
time="2021-06-25T08:13:07-05:00" level=info msg="check completed: HasNoProhibitedPackages" error="feature not implemented" result=ERROR
time="2021-06-25T08:13:07-05:00" level=info msg="running check: RunAsNonRoot"
time="2021-06-25T08:13:07-05:00" level=info msg="check completed: RunAsNonRoot" error="feature not implemented" result=ERROR
time="2021-06-25T08:13:07-05:00" level=info msg="running check: MaximumLayerPolicy"
time="2021-06-25T08:13:07-05:00" level=info msg="check completed: MaximumLayerPolicy" error="feature not implemented" result=ERROR
time="2021-06-25T08:13:07-05:00" level=info msg="running check: HasRequiredLabel"
time="2021-06-25T08:13:07-05:00" level=info msg="check completed: HasRequiredLabel" error="feature not implemented" result=ERROR
time="2021-06-25T08:13:07-05:00" level=info msg="running check: BasedOnUbi"
time="2021-06-25T08:13:09-05:00" level=info msg="check completed: BasedOnUbi" result=PASSED
time="2021-06-25T08:13:09-05:00" level=info msg="running check: HasLicense"
time="2021-06-25T08:13:09-05:00" level=info msg="check completed: HasLicense" error="feature not implemented" result=ERROR
time="2021-06-25T08:13:09-05:00" level=info msg="running check: HasMinimalVulnerabilities"
time="2021-06-25T08:13:09-05:00" level=info msg="check completed: HasMinimalVulnerabilities" error="feature not implemented" result=ERROR
time="2021-06-25T08:13:09-05:00" level=info msg="running check: HasUniqueTag"
time="2021-06-25T08:13:09-05:00" level=info msg="check completed: HasUniqueTag" error="feature not implemented" result=ERROR
{
    "image": "registry.access.redhat.com/ubi8/ubi:latest",
    "validation_lib_version": {
        "version": "unknown",
        "commit": "0ffccb1e68ce6d7a923d7c45eedcc9b9084e7581"
    },
    "results": {
        "Passed": [
            {
                "description": "Checking if the container's base image is based on UBI",
                "level": "best",
                "knowledge_base_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "policy_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            }
        ],
        "Failed": [],
        "Errors": [
            {
                "message": "The container image should not include Red Hat Enterprise Linux (RHEL) kernel packages.",
                "suggestion": "Remove any RHEL packages that are not distributable outside of UBI"
            },
            {
                "message": "A container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile"
            },
            {
                "message": "Uncompressed container images should have less than 40 layers. Too many layers within the container images can degrade container performance.",
                "suggestion": "Optimize your Dockerfile to consolidate and minimize the number of layers. Each RUN command will produce a new layer. Try combining RUN commands using \u0026\u0026 where possible."
            },
            {
                "message": "It is recommened that your image be based upon the Red Hat Universal Base Image (UBI)",
                "suggestion": "Change the FROM directive in your Dockerfile or Containerfile to FROM registry.access.redhat.com/ubi8/ubi"
            },
            {
                "message": "Container images must include terms and conditions applicable to the software including open source licensing information.",
                "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory."
            },
            {
                "message": "Components in the container image cannot contain any critical or important vulnerabilities, as defined at https://access.redhat.com/security/updates/classification",
                "suggestion": "Update your UBI image to the latest version or update the packages in your image to the latest versions distrubuted by Red Hat."
            },
            {
                "message": "Containers should have a tag other than latest, so that the image can be uniquely identfied.",
                "suggestion": "Add a tag to your image. Consider using Semantic Versioning. https://semver.org/"
            }
        ]
    }
}
```