### PR TITLE
Migrate check that confirms the image has under 40 layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.dylib
 bin
 preflight
+preflight-*.log
 
 # Test binary, build with `go test -c`
 *.test
@@ -31,4 +32,3 @@ preflight
 
 # Vagrant
 .vagrant
-

--- a/certification/internal/shell/less_than_max_layers.go
+++ b/certification/internal/shell/less_than_max_layers.go
@@ -1,16 +1,71 @@
 package shell
 
 import (
+	"encoding/json"
+	"os/exec"
+
+	"github.com/itchyny/gojq"
 	"github.com/komish/preflight/certification"
-	"github.com/komish/preflight/certification/errors"
 	"github.com/sirupsen/logrus"
 )
 
-type UnderLayerMaxCheck struct {
-}
+var acceptableLayerMax = 40
+
+type UnderLayerMaxCheck struct{}
 
 func (p *UnderLayerMaxCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
-	return false, errors.ErrFeatureNotImplemented
+	// TODO: if we're going have the image json on disk already, we should use it here instead of podman inspect-ing.
+	stdouterr, err := exec.Command("podman", "inspect", image).CombinedOutput()
+	if err != nil {
+		logger.Error("unable to execute inspect on the image: ", err)
+		return false, nil
+	}
+
+	// we must send gojq a []interface{}, so we have to convert our inspect output to that type
+	var inspectData []interface{}
+	err = json.Unmarshal(stdouterr, &inspectData)
+	if err != nil {
+		logger.Error("unable to parse podman inspect data for image")
+		logger.Debug("error marshaling podman inspect data: ", err)
+		logger.Trace("failure in attempt to convert the raw bytes from `podman inspect` to a []interface{}")
+		return false, err
+	}
+
+	jqQueryString := ".[0].RootFS.Layers"
+
+	query, err := gojq.Parse(jqQueryString)
+	if err != nil {
+		logger.Error("unable to parse podman inspect data for image")
+		logger.Debug("unable to successfully parse the gojq query string:", err)
+		return false, err
+	}
+
+	// gojq expects us to iterate in the event that our query returned multiple matching values, but we only expect one.
+	iter := query.Run(inspectData)
+	val, nextOk := iter.Next()
+
+	if !nextOk {
+		logger.Warn("did not receive any layer information when parsing container image")
+		// in this case, there was no data returned from jq, so we need to fail the check.
+		return false, nil
+	}
+
+	// gojq can return an error in iteration, so we need to check for that.
+	if err, ok := val.(error); ok {
+		logger.Error("unable to parse podman inspect data for image")
+		logger.Debug("unable to successfully parse the podman inspect output with the query string provided:", err)
+		// this is an error, as we didn't get the proper input from `podman inspect`
+		return false, err
+	}
+
+	layers := val.([]interface{})
+
+	logger.Debugf("detected %d layers in image", len(layers))
+	if len(layers) < acceptableLayerMax {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (p *UnderLayerMaxCheck) Name() string {


### PR DESCRIPTION
One more check migrated from the PoC repo.

The output for this one:

```json
$ ../preflight registry.access.redhat.com/ubi8/ubi:latest -p MaximumLayerPolicy
time="2021-06-25T11:32:42-05:00" level=info msg="target image: registry.access.redhat.com/ubi8/ubi:latest"
time="2021-06-25T11:32:42-05:00" level=info msg="downloading image"
time="2021-06-25T11:32:48-05:00" level=info msg="running check: MaximumLayerPolicy"
time="2021-06-25T11:32:49-05:00" level=debug msg="detected 2 layers in image"
time="2021-06-25T11:32:49-05:00" level=info msg="check completed: MaximumLayerPolicy" result=PASSED
{
    "image": "registry.access.redhat.com/ubi8/ubi:latest",
    "validation_lib_version": {
        "version": "unknown",
        "commit": "240fa8dd1118f58e672bdbda3a96b9fc098fd15d"
    },
    "results": {
        "Passed": [
            {
                "description": "Checking if container has less than 40 layers",
                "level": "better",
                "knowledge_base_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "policy_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            }
        ],
        "Failed": [],
        "Errors": []
    }
}
```

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>