### PR TITLE
Add check to ensure container image is not running as root

### DIFF
--- a/certification/engine/engine.go
+++ b/certification/engine/engine.go
@@ -73,6 +73,9 @@ var hasUniqueTagCheck certification.Check = &podmanexec.HasUniqueTagCheck{}
 var hasNoProhibitedCheck certification.Check = &podmanexec.HasNoProhibitedPackagesCheck{}
 
 var nameToChecksMap = map[string]certification.Check{
+	// NOTE(komish): these checks do not all apply to bundles, which is the current
+	// scope. Eventually, I expect we'll split out container checks to their
+	// on map and pass it to the CheckEngine when the right cobra command is invoked.
 	runAsNonRootCheck.Name():              runAsNonRootCheck,
 	underLayerMaxCheck.Name():             underLayerMaxCheck,
 	hasRequiredLabelCheck.Name():          hasRequiredLabelCheck,


### PR DESCRIPTION
This is actually a container/controller check, but it was stubbed so I filled it in. This will check the runtime id of the image by running `id -u`. 

Output looks like the following

```
$ ../preflight quay.io/opdev/pachyderm-operator:latest -c RunAsNonRoot
time="2021-06-25T12:33:59-05:00" level=info msg="target image: quay.io/opdev/pachyderm-operator:latest"
time="2021-06-25T12:33:59-05:00" level=info msg="downloading image"
time="2021-06-25T12:34:04-05:00" level=info msg="running check: RunAsNonRoot"
time="2021-06-25T12:34:07-05:00" level=debug msg="the runtime user id is 1001"
time="2021-06-25T12:34:07-05:00" level=info msg="check completed: RunAsNonRoot" result=PASSED
{
    "image": "quay.io/opdev/pachyderm-operator:latest",
    "validation_lib_version": {
        "version": "unknown",
        "commit": "f6c332e91b221f7abd4ce6d666314d6705b02731"
    },
    "results": {
        "Passed": [
            {
                "description": "Checking if container runs as the root user",
                "level": "best",
                "knowledge_base_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide",
                "check_url": "https://connect.redhat.com/zones/containers/container-certification-policy-guide"
            }
        ],
        "Failed": [],
        "Errors": []
    }
}
```

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>