### PR TITLE
Ensure podman run commands replace the entrypoint

### DIFF
--- a/certification/internal/shell/base_on_ubi.go
+++ b/certification/internal/shell/base_on_ubi.go
@@ -11,7 +11,7 @@ import (
 type BaseOnUBICheck struct{}
 
 func (p *BaseOnUBICheck) Validate(image string, logger *logrus.Logger) (bool, error) {
-	stdouterr, err := exec.Command("podman", "run", "--rm", "-it", image, "cat", "/etc/os-release").CombinedOutput()
+	stdouterr, err := exec.Command("podman", "run", "--rm", "-it", "--entrypoint", "cat", image, "/etc/os-release").CombinedOutput()
 	if err != nil {
 		logger.Error("unable to inspect the os-release file in the target container: ", err)
 		return false, err

--- a/certification/internal/shell/has_license.go
+++ b/certification/internal/shell/has_license.go
@@ -11,7 +11,7 @@ import (
 type HasLicenseCheck struct{}
 
 func (p *HasLicenseCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
-	stdouterr, err := exec.Command("podman", "run", "--rm", image, "ls", "-A", "/licenses").CombinedOutput()
+	stdouterr, err := exec.Command("podman", "run", "-it", "--rm", "--entrypoint", "ls", image, "-A", "/licenses").CombinedOutput()
 	result := string(stdouterr)
 	if err != nil {
 		if strings.Contains(result, "No such file or directory") || result == "" {


### PR DESCRIPTION
This fixes a bug where running these checks against an image that has a predefined entrypoint will fail. This is because these commands are passed to the entrypoint. Instead, we want to overwrite the entrypoint to perform our checks.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>