### PR TITLE
add test containerfiles to help evaluate tool functionality

### DIFF
--- a/tests/containerfiles/Dockerfile.FailsAllChecks
+++ b/tests/containerfiles/Dockerfile.FailsAllChecks
@@ -1,0 +1,46 @@
+FROM docker.io/ubuntu:20.04
+
+RUN apt update && apt -y install kpatch
+
+RUN touch file1.txt
+RUN touch file2.txt
+RUN touch file3.txt
+RUN touch file4.txt
+RUN touch file5.txt
+RUN touch file6.txt
+RUN touch file7.txt
+RUN touch file8.txt
+RUN touch file9.txt
+RUN touch file10.txt
+RUN touch file11.txt
+RUN touch file12.txt
+RUN touch file13.txt
+RUN touch file14.txt
+RUN touch file15.txt
+RUN touch file16.txt
+RUN touch file17.txt
+RUN touch file18.txt
+RUN touch file19.txt
+RUN touch file20.txt
+RUN touch file21.txt
+RUN touch file22.txt
+RUN touch file23.txt
+RUN touch file24.txt
+RUN touch file25.txt
+RUN touch file26.txt
+RUN touch file27.txt
+RUN touch file28.txt
+RUN touch file29.txt
+RUN touch file30.txt
+RUN touch file31.txt
+RUN touch file32.txt
+RUN touch file33.txt
+RUN touch file34.txt
+RUN touch file35.txt
+RUN touch file36.txt
+RUN touch file37.txt
+RUN touch file38.txt
+RUN touch file39.txt
+RUN touch file40.txt
+
+USER root

--- a/tests/containerfiles/Dockerfile.PassesAllChecks
+++ b/tests/containerfiles/Dockerfile.PassesAllChecks
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+RUN useradd preflightuser
+
+COPY --chown=preflightuser:preflightuser example-license.txt /licenses
+
+LABEL name="preflight test image" \ 
+      vendor="preflight test vendor" \
+      version="1" \
+      release="1" \
+      summary="testing the preflight tool" \
+      description="test the preflight tool"
+
+USER preflightuser

--- a/tests/containerfiles/example-license.txt
+++ b/tests/containerfiles/example-license.txt
@@ -1,0 +1,1 @@
+This is an example license file! Hello, World!


### PR DESCRIPTION
This just adds a couple of container file that can be used to generate test targets. These will probably need tweaking as we add additional tests (specifically scorecard/bundle-specific tests), but it's more of a starting point.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>