### PR TITLE
Disable the local image path

### DIFF
--- a/certification/internal/shell/engine.go
+++ b/certification/internal/shell/engine.go
@@ -65,9 +65,9 @@ func (e *CheckEngine) ExecuteChecks(logger *logrus.Logger) {
 		// if we downloaded an image to disk, lets test against that.
 		// COMMENTED: tests aren't currently written to support this
 		// remove if we decide we do not care to have a tarball.
-		if len(e.localImagePath) != 0 {
-			targetImage = e.localImagePath
-		}
+		// if len(e.localImagePath) != 0 {
+		// 	targetImage = e.localImagePath
+		// }
 
 		logger.Info("running check: ", check.Name())
 		// run the validation


### PR DESCRIPTION
The local image path as the target image was inadvertently enabled. This is
causing all tests to fail. Comment it again.

Signed-off-by: Brad P. Crochet <brad@redhat.com>