### PR TITLE
Make the runs_as_nonroot test more robust

### DIFF
--- a/certification/internal/shell/runs_as_nonroot.go
+++ b/certification/internal/shell/runs_as_nonroot.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"bytes"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -12,19 +13,25 @@ import (
 type RunAsNonRootCheck struct{}
 
 func (p *RunAsNonRootCheck) Validate(image string, logger *logrus.Logger) (bool, error) {
-	stdouterr, err := exec.Command("podman", "run", "-it", "--rm", "--entrypoint", "id", image, "-u").CombinedOutput()
+	cmd := exec.Command("podman", "run", "-it", "--rm", "--entrypoint", "id", image, "-u")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
 	if err != nil {
 		logger.Error("unable to get the id of the runtime user of this image")
-		logger.Debug(string(stdouterr), err)
+		logger.Debugf("stdout: %s", out.String())
+		logger.Debugf("stderr: %s", stderr.String())
 		return false, err
 	}
 
 	// The output we get from the exec.Command includes returns
-	stdouterrString := strings.TrimSuffix(string(stdouterr), "\r\n")
-	uid, err := strconv.Atoi(stdouterrString)
+	stdoutString := strings.TrimSpace(out.String())
+	uid, err := strconv.Atoi(stdoutString)
 	if err != nil {
 		logger.Error("unable to determine the runtime user id of the image")
-		logger.Debug("expected a value that could be converted to an integer, and got: ", stdouterr)
+		logger.Debug("expected a value that could be converted to an integer, and got: ", out.String())
 		return false, err
 	}
 


### PR DESCRIPTION
If there was any output on stderr, this check would usually fail. This
patch makes it a bit more robust by separating stdout and stderr, and
just relying on the stdout stream. It also uses TrimSpace instead of
TrimSuffix, as the suffix wasn't always CRLF, but sometime just LF,
and this would also cause the check to fail.

Signed-off-by: Brad P. Crochet <brad@redhat.com>