### PR TITLE
Force use of podman when running operator-sdk bundle validate

### DIFF
--- a/certification/internal/shell/validate_operator_bundle.go
+++ b/certification/internal/shell/validate_operator_bundle.go
@@ -12,7 +12,7 @@ type ValidateOperatorBundlePolicy struct {
 }
 
 func (p ValidateOperatorBundlePolicy) Validate(bundle string, logger *logrus.Logger) (bool, error) {
-	stdouterr, err := exec.Command("operator-sdk", "bundle", "validate", "--verbose", bundle).CombinedOutput()
+	stdouterr, err := exec.Command("operator-sdk", "bundle", "validate", "-b", "podman", "--verbose", bundle).CombinedOutput()
 	if err != nil {
 		logger.Error("Error will executing operator-sdk validate bundle: ", err)
 		return false, err


### PR DESCRIPTION
We want to default the usage of podman (at least for now) when running
the bundle validate.

Signed-off-by: Brad P. Crochet <brad@redhat.com>